### PR TITLE
Adds JSON output for get and history commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ decrypt=true
 profile=my-profile
 region=us-east-1
 key=3example-89a6-4880-b544-73ad3db2ff3b
+output=json
 ```
 
 A few notes on configuration:
 * When setting the region, the `AWS_REGION` env var takes top priority, followed by the setting in `.ssmshrc`, followed by the value set in the AWS profile (if configured)
 * When setting the profile, the `AWS_PROFILE` env var takes top priority, followed by the setting in `.ssmshrc`
 * If you set a KMS key, it will only work in the region where that key is located. You can use the `key` command while in the shell to change the key.
+* If the configuration file has `output=json`, the results of the `get` and `history` commands will be printed in JSON. The fields of the JSON results will be the same as in the respective Go structs. See the [`Parameter`](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#Parameter) and [`ParameterHistory`](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#ParameterHistory) docs.
 
 ## Usage
 ### Help

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -1,21 +1,27 @@
 package commands
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/abiosoft/ishell"
+	"github.com/bwhaley/ssmsh/config"
 	"github.com/bwhaley/ssmsh/parameterstore"
 )
 
 type fn func(*ishell.Context)
 
-var shell *ishell.Shell
-var ps *parameterstore.ParameterStore
+var (
+	shell *ishell.Shell
+	ps    *parameterstore.ParameterStore
+	cfg   *config.Config
+)
 
 // Init initializes the ssmsh subcommands
-func Init(iShell *ishell.Shell, iPs *parameterstore.ParameterStore) {
+func Init(iShell *ishell.Shell, iPs *parameterstore.ParameterStore, iCfg *config.Config) {
 	shell = iShell
 	ps = iPs
+	cfg = iCfg
 	registerCommand("cd", "change your relative location within the parameter store", cd, cdUsage)
 	registerCommand("cp", "copy source to dest", cp, cpUsage)
 	registerCommand("decrypt", "toggle parameter decryption", decrypt, decryptUsage)
@@ -92,4 +98,22 @@ func trim(with []string) (without []string) {
 		without = append(without, strings.TrimSpace(with[i]))
 	}
 	return without
+}
+
+func printResult(result interface{}) {
+	switch cfg.Default.Output {
+	case "json":
+		printJSON(result)
+	default:
+		shell.Printf("%+v\n", result)
+	}
+}
+
+func printJSON(result interface{}) {
+	resultJSON, err := json.MarshalIndent(result, "", "    ")
+	if err != nil {
+		shell.Println("Error with result: ", err)
+	} else {
+		shell.Println(string(resultJSON))
+	}
 }

--- a/commands/get.go
+++ b/commands/get.go
@@ -24,7 +24,7 @@ func get(c *ishell.Context) {
 				shell.Println("Error: ", err)
 			} else {
 				if len(resp) >= 1 {
-					shell.Printf("%+v\n", resp)
+					printResult(resp)
 				}
 			}
 		}

--- a/commands/history.go
+++ b/commands/history.go
@@ -21,6 +21,6 @@ func history(c *ishell.Context) {
 	if err != nil {
 		shell.Println("Error: ", err)
 	} else {
-		shell.Printf("%+v\n", resp)
+		printResult(resp)
 	}
 }

--- a/commands/put.go
+++ b/commands/put.go
@@ -270,7 +270,6 @@ func validatePolicies(s string) (err error) {
 		}
 	}
 	policyBytes, err := json.Marshal(policySet)
-	// shell.Printf("Policies: %v\n", string(policyBytes))
 	putParamInput.Policies = aws.String(string(policyBytes))
 	putParamInput.Tier = aws.String(AdvancedTier)
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 		Region    string
 		Overwrite bool
 		Type      string
+		Output    string
 	}
 }
 

--- a/ssmsh.go
+++ b/ssmsh.go
@@ -41,7 +41,7 @@ func main() {
 		shell.Println("Error initializing session. Is your authentication correct?", err)
 		os.Exit(1)
 	}
-	commands.Init(shell, &ps)
+	commands.Init(shell, &ps, &cfg)
 
 	if *file == "-" {
 		processStdin(shell)


### PR DESCRIPTION
Adds a new configuration file option:`output`. If `output=json`, the results of the `get` and `history` commands will be printed in JSON. The fields of the JSON results will be the same as in the respective Go structs. See the [`Parameter`](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#Parameter) and [`ParameterHistory`](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#ParameterHistory) docs.