### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+
+env:
+  SSMSH_VERSION: 1.4.3
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.32 # Latest version from https://github.com/golangci/golangci-lint/releases/
+          args: --enable golint
+  test-and-build:
+    name: Test and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+      - name: Vet
+        run: go vet -v $(go list ./...)
+      - name: Test
+        run: go test -v $(go list ./...)
+      - name: Build
+        run: make build

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,14 @@ ifeq "$(VERSION)" ""
     $(error must define SSMSH_VERSION env var)
 endif
 
-
 GOVERSION := $(shell go version | grep 1.13)
 ifeq "$(GOVERSION)" ""
     $(error must be running Go version 1.13.x)
+endif
+
+ifndef $(GOPATH)
+   GOPATH=$(shell go env GOPATH)
+   export GOPATH
 endif
 
 all: test build


### PR DESCRIPTION
Hi, I'm not a programmer (just do devops currently), but I'm familiar enough with Github Actions to contribute something. 

Added:
- A job to lint, using `golangci-lint`. It looks like it includes [several different linters](https://golangci-lint.run/usage/linters) by default, and I also added `golint` to that list, since that's what was used in the Makefile.
- A job to vet, test, then run the Makefile to build.
- I also added a bit in the Makefile to set the `GOPATH` if it isn't set. I was having trouble with it not being set by default in the Action for some reason.

Should close issue #16.

Oh and thank you for making this. It's so so handy to move around Parameter Store like a filesystem, and the `mv` command has been helpful several times already. :+1: 