### PR TITLE
Add goreleaser

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.15
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.15
       - name: Vet
         run: go vet -v $(go list ./...)
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
 
 env:
-  SSMSH_VERSION: 1.4.3
   AWS_DEFAULT_REGION: us-east-1
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w -X main.Version={{.Version}}
+
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - none*
+
+changelog:
+  sort: asc
+
+brews:
+  - tap:
+      owner: bwhaley
+      name: ssmsh
+    description: A shell for the EC2 Parameter Store
+    homepage: https://github.com/bwhaley/ssmsh
+    license: MIT

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 
 VERSION := $(shell echo ${SSMSH_VERSION})
 ifeq "$(VERSION)" ""
-    $(error must define SSMSH_VERSION env var)
+    VERSION="auto-build"
 endif
 
 GOVERSION := $(shell go version | grep 1.15)

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ ifeq "$(VERSION)" ""
     $(error must define SSMSH_VERSION env var)
 endif
 
-GOVERSION := $(shell go version | grep 1.13)
+GOVERSION := $(shell go version | grep 1.15)
 ifeq "$(GOVERSION)" ""
-    $(error must be running Go version 1.13.x)
+    $(error must be running Go version 1.15.x)
 endif
 
 ifndef $(GOPATH)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,32 @@ ssmsh is an interactive shell for the EC2 Parameter Store. Features:
 * Submit batch commands with the `-file` flag
 * Inline commands
 
-
 ## Installation
 
-1. Download [here](https://github.com/bwhaley/ssmsh/releases) or clone and build from this repo.
-2. Set up [AWS credentials](http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).
+### Binaries
+
+Download binaries for MacOS, Linux, or Windows from the latest release [here](https://github.com/bwhaley/ssmsh/releases).
+
+### Homebrew
+
+There is a Homebrew tap published to this repo, for installation on both MacOS and Linux. Add the tap and install with:
+
+```bash
+brew tap bwhaley/ssmsh https://github.com/bwhaley/ssmsh
+brew install ssmsh
+```
+
+### Nix
+
+There is also [a Nix package](https://search.nixos.org/packages?channel=unstable&show=ssmsh&query=ssmsh) available for MacOS and Linux:
+
+```bash
+nix-env -i ssmsh
+```
 
 ## Configuration
+
+Set up [AWS credentials](http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).
 
 You can set up a `.ssmshrc` to configure `ssmsh`. By default, `ssmsh` will load `~/.ssmshrc` if it exists. Use the `-config` argument to set a different path.
 

--- a/README.md
+++ b/README.md
@@ -260,10 +260,10 @@ $ ssmsh put name=/dev/app/domain value="www.example.com" type=String description
 MIT
 
 ## Contributing/compiling
-1. Ensure you have at least go v1.13
+1. Ensure you have at least go v1.15
 ```
 $ go version
-go version go1.13.8 darwin/amd64
+go version go1.15.7 darwin/amd64
 ```
 2. Ensure your `$GOPATH` exists and is in your `$PATH`
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bwhaley/ssmsh
 
-go 1.13
+go 1.15
 
 require (
 	github.com/abiosoft/ishell v2.0.1-0.20181228190644-8b8aa74a8512+incompatible


### PR DESCRIPTION
Ok I've got this in a place where I'm comfortable PR'ing it. (Made a bunch of [test releases](https://github.com/dbirks/ssmsh/releases) on my fork.)

This runs goreleaser on every push of a tag to build binaries, makes a Github Release, and then commits a `ssmsh.rb` file to master for the homebrew package.

More notes:
- I bumped Go to 1.15 because I couldn't get 1.13 from my package repos, and it still built and ran nicely for me.
- I couldn't find a way to easily trigger goreleaser on a push to the master branch `AND` a tag push (it always acts like it's the branch `OR` the tag), so I just have it triggered on tag pushes. 
- I've tested installing the homebrew tap on Linux (pointing to my fork), and it worked nicely, but MacOS is untested.
- It was also super easy to have it build a Windows binary, but that's untested as well.
- In the archive section, I set `none*` to have it only include the binary in the tar.gz or zip.

And please feel free to change/rework any pf this to your liking. I made several "executive decisions" with the readme for example. :slightly_smiling_face:  Trying to figure out how to word the different install methods.

Closes #26 