### PR TITLE
(brew): Remove `bottle :uneeded`

### DIFF
--- a/ssmsh.rb
+++ b/ssmsh.rb
@@ -7,7 +7,6 @@ class Ssmsh < Formula
   homepage "https://github.com/bwhaley/ssmsh"
   version "1.4.5"
   license "MIT"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/bwhaley/ssmsh/releases/download/v1.4.5/ssmsh_1.4.5_darwin_amd64.tar.gz"


### PR DESCRIPTION
Per https://github.com/Homebrew/homebrew-core/issues/75943.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the bwhaley/ssmsh tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/bwhaley/homebrew-ssmsh/ssmsh.rb:10
```